### PR TITLE
feat: cache aside strategy with localStorage implemented

### DIFF
--- a/app/_components/Nav/MobileNav.tsx
+++ b/app/_components/Nav/MobileNav.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import { signInWithGoogle, signOutAction } from "@/app/_lib/actions";
 import { Button } from "@/components/ui/button";
 import type { Session } from "next-auth";
 import Image from "next/image";
 import Link from "next/link";
+import { useState } from "react";
 import { NAV_LINKS } from "./navLinks";
 
 interface MobileNavProps {
@@ -11,98 +14,113 @@ interface MobileNavProps {
 }
 
 export default function MobileNav({ publicUserID, session }: MobileNavProps) {
+  const [open, setOpen] = useState(false);
+
   return (
     <div className="md:hidden relative">
-      <input type="checkbox" id="nav-toggle" className="hidden peer" />
-
-      <label
-        htmlFor="nav-toggle"
-        className="cursor-pointer p-2 text-foreground/70 hover:text-foreground rounded-lg transition-colors hover:bg-accent peer-checked:hidden"
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="cursor-pointer p-2 text-foreground/70 hover:text-foreground rounded-lg transition-colors hover:bg-accent"
+        aria-expanded={open}
+        aria-controls="mobile-nav-menu"
+        aria-label={open ? "Close menu" : "Open menu"}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M4 6h16M4 12h16M4 18h16"
-          />
-        </svg>
-      </label>
-
-      <label
-        htmlFor="nav-toggle"
-        className="cursor-pointer p-2 text-foreground/70 hover:text-foreground rounded-lg transition-colors hover:bg-accent hidden peer-checked:flex"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M6 18L18 6M6 6l12 12"
-          />
-        </svg>
-      </label>
-
-      <div className="hidden peer-checked:flex flex-col gap-1 bg-white/90 backdrop-blur-xl border border-black/[0.06] rounded-2xl shadow-lg p-3 absolute top-full right-0 mt-2 w-56 z-50">
-        {NAV_LINKS(publicUserID).map(({ href, label }) => (
-          <Link
-            key={href}
-            href={href}
-            className="px-3 py-2 text-sm font-medium text-foreground/80 rounded-lg transition-colors hover:bg-accent hover:text-foreground"
+        {open ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
           >
-            {label}
-          </Link>
-        ))}
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        ) : (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4 6h16M4 12h16M4 18h16"
+            />
+          </svg>
+        )}
+      </button>
 
-        <div className="mt-2 pt-2 border-t border-border">
-          {session?.user ? (
-            <div className="space-y-2">
-              <Link
-                href={publicUserID ? `/profile/${publicUserID}` : "#"}
-                className="flex items-center gap-2.5 px-3 py-2 rounded-lg transition-colors hover:bg-accent"
-              >
-                <Image
-                  src={session.user.image || "/default-avatar.png"}
-                  alt={session.user.name ?? "User"}
-                  width={28}
-                  height={28}
-                  className="rounded-full ring-1 ring-black/[0.08]"
-                />
-                <span className="text-sm font-medium text-foreground">
-                  {session.user.name?.split(" ")[0]}
-                </span>
-              </Link>
-              <form action={signOutAction}>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="w-full justify-start text-muted-foreground"
+      {open && (
+        <div
+          id="mobile-nav-menu"
+          className="flex flex-col gap-1 bg-white/90 backdrop-blur-xl border border-black/[0.06] rounded-2xl shadow-lg p-3 absolute top-full right-0 mt-2 w-56 z-50"
+        >
+          {NAV_LINKS(publicUserID).map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setOpen(false)}
+              className="px-3 py-2 text-sm font-medium text-foreground/80 rounded-lg transition-colors hover:bg-accent hover:text-foreground"
+            >
+              {label}
+            </Link>
+          ))}
+
+          <div className="mt-2 pt-2 border-t border-border">
+            {session?.user ? (
+              <div className="space-y-2">
+                <Link
+                  href={publicUserID ? `/profile/${publicUserID}` : "#"}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg transition-colors hover:bg-accent"
                 >
-                  Sign Out
+                  <Image
+                    src={session.user.image || "/default-avatar.png"}
+                    alt={session.user.name ?? "User"}
+                    width={28}
+                    height={28}
+                    className="rounded-full ring-1 ring-black/[0.08]"
+                  />
+                  <span className="text-sm font-medium text-foreground">
+                    {session.user.name?.split(" ")[0]}
+                  </span>
+                </Link>
+                <form action={signOutAction}>
+                  <Button
+                    type="submit"
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-start text-muted-foreground"
+                    onClick={() => setOpen(false)}
+                  >
+                    Sign Out
+                  </Button>
+                </form>
+              </div>
+            ) : (
+              <form action={signInWithGoogle}>
+                <Button
+                  type="submit"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => setOpen(false)}
+                >
+                  Sign In
                 </Button>
               </form>
-            </div>
-          ) : (
-            <form action={signInWithGoogle}>
-              <Button size="sm" className="w-full">
-                Sign In
-              </Button>
-            </form>
-          )}
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/app/_components/Profile/ClearCacheButton.tsx
+++ b/app/_components/Profile/ClearCacheButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { clearAppCache } from "@/app/_lib/cache";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import toast, { Toaster } from "react-hot-toast";
+
+export default function ClearCacheButton() {
+  const [cleared, setCleared] = useState(false);
+
+  const handleClear = () => {
+    clearAppCache();
+    setCleared(true);
+    toast.success("Cache cleared successfully");
+    setTimeout(() => setCleared(false), 2000);
+  };
+
+  return (
+    <>
+      <Toaster />
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleClear}
+        disabled={cleared}
+        className="gap-2"
+      >
+        <Trash2 className="size-3.5" />
+        {cleared ? "Cleared" : "Clear Cache"}
+      </Button>
+    </>
+  );
+}

--- a/app/_components/ReadingList/ReadingListView.tsx
+++ b/app/_components/ReadingList/ReadingListView.tsx
@@ -9,9 +9,11 @@ import { ReadingListDBRow } from "@/app/_lib/types";
 export default function ReadingListView({
   readingList,
   favoriteBookIds,
+  onStatusChangeSuccess,
 }: {
   readingList: ReadingListDBRow[];
   favoriteBookIds: string[];
+  onStatusChangeSuccess?: () => void | Promise<void>;
 }) {
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
 
@@ -53,6 +55,7 @@ export default function ReadingListView({
         readingList={readingList}
         favoriteBookIds={favoriteBookIds}
         viewMode={viewMode}
+        onStatusChangeSuccess={onStatusChangeSuccess}
       />
     </>
   );

--- a/app/_components/ReadingList/StatusSelect.tsx
+++ b/app/_components/ReadingList/StatusSelect.tsx
@@ -3,6 +3,12 @@
 import { useTransition, useState, useRef, useEffect } from "react";
 import { putChangeBookStatusAction } from "@/app/_lib/actions";
 import { ReadingListStatus } from "@/app/_lib/types";
+import {
+  bookCacheKey,
+  invalidateCache,
+  invalidateCacheByPrefix,
+  READING_LIST_KEY_PREFIX,
+} from "@/app/_lib/cache";
 import toast from "react-hot-toast";
 import { ChevronDown } from "lucide-react";
 
@@ -19,9 +25,13 @@ function getStatusOption(status: ReadingListStatus) {
 export default function StatusSelect({
   readingListId,
   currentStatus,
+  googleBookId,
+  onStatusUpdated,
 }: {
   readingListId: string;
   currentStatus: ReadingListStatus;
+  googleBookId?: string;
+  onStatusUpdated?: () => void | Promise<void>;
 }) {
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
@@ -42,7 +52,15 @@ export default function StatusSelect({
     if (newStatus === currentStatus) return;
     startTransition(async () => {
       const result = await putChangeBookStatusAction(newStatus, readingListId);
-      if (result?.error) toast.error(result.error);
+      if (result?.error) {
+        toast.error(result.error);
+      } else {
+        invalidateCacheByPrefix(READING_LIST_KEY_PREFIX);
+        if (googleBookId) {
+          invalidateCache(bookCacheKey(googleBookId));
+        }
+        await onStatusUpdated?.();
+      }
     });
   };
 

--- a/app/_components/ReadingListTableBody.tsx
+++ b/app/_components/ReadingListTableBody.tsx
@@ -31,10 +31,12 @@ const ReadingListCards = ({
   readingList,
   favoriteBookIds = [],
   viewMode = "grid",
+  onStatusChangeSuccess,
 }: {
   readingList: ReadingListDBRow[];
   favoriteBookIds?: string[];
   viewMode?: "grid" | "list";
+  onStatusChangeSuccess?: () => void | Promise<void>;
 }) => {
   if (readingList.length === 0) {
     return (
@@ -87,6 +89,8 @@ const ReadingListCards = ({
                   <StatusSelect
                     readingListId={item.readingListId}
                     currentStatus={status}
+                    googleBookId={books.google_book_id}
+                    onStatusUpdated={onStatusChangeSuccess}
                   />
                 </div>
 
@@ -153,6 +157,8 @@ const ReadingListCards = ({
                   <StatusSelect
                     readingListId={item.readingListId}
                     currentStatus={status}
+                    googleBookId={books.google_book_id}
+                    onStatusUpdated={onStatusChangeSuccess}
                   />
                   <Button asChild variant="ghost" size="xs">
                     <Link href={`/books/${books.google_book_id}`}>View</Link>

--- a/app/_lib/actions.ts
+++ b/app/_lib/actions.ts
@@ -77,7 +77,8 @@ export const removeBookFromListAction = async (bookId: string) => {
     return { error: "Unable to remove book from users list", status: 500 };
   }
 
-  redirect(`/reading-list/${userId}`);
+  revalidatePath(`/reading-list/${userId}`);
+  return { success: true as const, userId };
 };
 
 export const addNotesToBook = async (formData: FormData) => {

--- a/app/_lib/cache.ts
+++ b/app/_lib/cache.ts
@@ -1,0 +1,67 @@
+const APP_CACHE_PREFIX = "librislist:";
+
+export const BOOK_KEY_PREFIX = `${APP_CACHE_PREFIX}book:`;
+export const READING_LIST_KEY_PREFIX = `${APP_CACHE_PREFIX}reading-list:`;
+
+export const BOOK_TTL_MS = 30 * 60 * 1000;
+export const READING_LIST_TTL_MS = 10 * 60 * 1000;
+
+export const bookCacheKey = (bookId: string) => `${BOOK_KEY_PREFIX}${bookId}`;
+export const readingListCacheKey = (userId: string) =>
+  `${READING_LIST_KEY_PREFIX}${userId}`;
+
+interface CacheEntry<T> {
+  data: T;
+  cachedAt: number;
+}
+
+export function getCache<T>(key: string, ttlMs: number): T | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+
+    const entry: CacheEntry<T> = JSON.parse(raw);
+    if (Date.now() - entry.cachedAt > ttlMs) {
+      localStorage.removeItem(key);
+      return null;
+    }
+    return entry.data;
+  } catch {
+    localStorage.removeItem(key);
+    return null;
+  }
+}
+
+export function setCache<T>(key: string, data: T): void {
+  if (typeof window === "undefined") return;
+  try {
+    const entry: CacheEntry<T> = { data, cachedAt: Date.now() };
+    localStorage.setItem(key, JSON.stringify(entry));
+  } catch {
+    // localStorage full or unavailable — silently skip
+  }
+}
+
+export function invalidateCache(...keys: string[]): void {
+  if (typeof window === "undefined") return;
+  for (const key of keys) {
+    localStorage.removeItem(key);
+  }
+}
+
+export function invalidateCacheByPrefix(prefix: string): void {
+  if (typeof window === "undefined") return;
+  const toRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(prefix)) toRemove.push(key);
+  }
+  for (const key of toRemove) {
+    localStorage.removeItem(key);
+  }
+}
+
+export function clearAppCache(): void {
+  invalidateCacheByPrefix(APP_CACHE_PREFIX);
+}

--- a/app/api/reading-list/[userId]/route.ts
+++ b/app/api/reading-list/[userId]/route.ts
@@ -3,22 +3,24 @@ import { getPublicUserID } from "@/app/_lib/service";
 import { getUserReadingList } from "@/app/_lib/service";
 import { NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: NextRequest) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
   const session = await auth();
   if (!session?.user?.email) {
     return NextResponse.json({ error: "Not signed in" }, { status: 401 });
   }
 
+  const { userId } = await params;
   const currentUserId = await getPublicUserID(session.user.email);
-  const { searchParams } = new URL(request.url);
-  const userId = searchParams.get("userId")?.trim() ?? "";
 
-  if (userId && userId !== currentUserId) {
+  if (userId !== currentUserId) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   try {
-    const data = await getUserReadingList(userId || currentUserId);
+    const data = await getUserReadingList(userId);
     return NextResponse.json(data);
   } catch (err) {
     console.error(err);

--- a/app/books/[bookId]/page.tsx
+++ b/app/books/[bookId]/page.tsx
@@ -15,6 +15,15 @@ import {
   putChangeBookStatusAction,
   removeBookFromListAction,
 } from "@/app/_lib/actions";
+import {
+  getCache,
+  setCache,
+  invalidateCache,
+  invalidateCacheByPrefix,
+  bookCacheKey,
+  BOOK_TTL_MS,
+  READING_LIST_KEY_PREFIX,
+} from "@/app/_lib/cache";
 import { resolveCoverImageSrc } from "@/app/_lib/coverImage";
 import Loader from "@/app/loading";
 import axios from "axios";
@@ -62,7 +71,15 @@ export default function BookDetails() {
     if (!bookId) return;
     async function load() {
       try {
-        const { data: bookData } = await axios.get<Book>(`/api/books/${bookId}`);
+        const cacheKey = bookCacheKey(String(bookId));
+        let bookData = getCache<Book>(cacheKey, BOOK_TTL_MS);
+
+        if (!bookData) {
+          const res = await axios.get<Book>(`/api/books/${bookId}`);
+          bookData = res.data;
+          setCache(cacheKey, bookData);
+        }
+
         setBook(bookData);
         const bookDbId = bookData?.volumeInfo?.id;
         if (bookDbId) {
@@ -117,10 +134,13 @@ export default function BookDetails() {
           if (result.error) {
             toast.error(result.error);
             return;
-          } else {
-            toast.success(`Removed ${title} from your reading list`);
-            return;
           }
+          invalidateCacheByPrefix(READING_LIST_KEY_PREFIX);
+          toast.success(`Removed ${title} from your reading list`);
+          if ("userId" in result && result.userId) {
+            router.push(`/reading-list/${result.userId}`);
+          }
+          return;
         }
         toast.error("Cannot remove book since no book id was found");
         return;
@@ -144,6 +164,7 @@ export default function BookDetails() {
         } else if ("insertError" in result) {
           toast.error(result.insertError);
         } else {
+          invalidateCacheByPrefix(READING_LIST_KEY_PREFIX);
           toast.success("Book added to your reading list");
           setTimeout(() => {
             router.push(`/reading-list/${readingListObj.user_id}`);
@@ -178,6 +199,8 @@ export default function BookDetails() {
     if (result?.error) {
       toast.error(result.error);
     } else {
+      invalidateCacheByPrefix(READING_LIST_KEY_PREFIX);
+      invalidateCache(bookCacheKey(String(bookId)));
       toast.success("Status updated");
       setReadingListObj((prev) => ({ ...prev, status }));
     }

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -14,7 +14,8 @@ import FavoriteBookSearch from "@/app/_components/Profile/FavoriteBookSearch";
 import FavoriteBookCard from "@/app/_components/Profile/FavoriteBookCard";
 import ProfileVisibilityToggle from "@/app/_components/Profile/ProfileVisibilityToggle";
 import ProfileAvatar from "@/app/_components/Profile/ProfileAvatar";
-import { Lock, Sparkles } from "lucide-react";
+import ClearCacheButton from "@/app/_components/Profile/ClearCacheButton";
+import { Lock, Settings, Sparkles } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -206,6 +207,31 @@ export default async function ProfilePage({ params }: UserPageParams) {
                   </div>
                 </div>
               ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Settings */}
+      {isOwner && (
+        <Card className="border-border/50">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Settings className="size-5 text-muted-foreground" />
+              Settings
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  Clear cached data
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Remove locally stored book and reading list data from this browser.
+                </p>
+              </div>
+              <ClearCacheButton />
             </div>
           </CardContent>
         </Card>

--- a/app/reading-list/[userId]/_components/ReadingListPageContent.tsx
+++ b/app/reading-list/[userId]/_components/ReadingListPageContent.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import axios from "axios";
+import Filter from "@/app/_components/ReadingList/Filter";
+import ReadingListView from "@/app/_components/ReadingList/ReadingListView";
+import Loader from "@/app/loading";
+import { ReadingListDBRow } from "@/app/_lib/types";
+import {
+  getCache,
+  setCache,
+  readingListCacheKey,
+  READING_LIST_TTL_MS,
+} from "@/app/_lib/cache";
+
+const VALID_STATUSES = new Set<string>([
+  "to_read",
+  "reading",
+  "completed",
+  "all",
+]);
+
+function filterByStatus(
+  list: ReadingListDBRow[],
+  status: string | null
+): ReadingListDBRow[] {
+  if (!status || status === "all" || !VALID_STATUSES.has(status)) return list;
+  return list.filter((item) => item.status === status);
+}
+
+export default function ReadingListPageContent({
+  userId,
+  isOwner,
+  profileName,
+  favoriteBookIds,
+  initialData,
+}: {
+  userId: string;
+  isOwner: boolean;
+  profileName: string;
+  favoriteBookIds: string[];
+  initialData?: ReadingListDBRow[];
+}) {
+  const searchParams = useSearchParams();
+  const statusFilter = searchParams.get("status");
+
+  const [readingList, setReadingList] = useState<ReadingListDBRow[] | null>(
+    initialData ?? null
+  );
+  const [isLoading, setIsLoading] = useState(!initialData);
+
+  const refetchReadingList = useCallback(async () => {
+    if (!isOwner) return;
+    try {
+      const cacheKey = readingListCacheKey(userId);
+      const { data } = await axios.get<ReadingListDBRow[]>(
+        `/api/reading-list/${userId}`
+      );
+      setCache(cacheKey, data);
+      setReadingList(data);
+    } catch (err) {
+      console.error("Failed to refresh reading list", err);
+    }
+  }, [userId, isOwner]);
+
+  useEffect(() => {
+    if (!isOwner) return;
+
+    const cacheKey = readingListCacheKey(userId);
+    const cached = getCache<ReadingListDBRow[]>(cacheKey, READING_LIST_TTL_MS);
+
+    if (cached) {
+      setReadingList(cached);
+      setIsLoading(false);
+      return;
+    }
+
+    async function fetchList() {
+      try {
+        const { data } = await axios.get<ReadingListDBRow[]>(
+          `/api/reading-list/${userId}`
+        );
+        setCache(cacheKey, data);
+        setReadingList(data);
+      } catch (err) {
+        console.error("Failed to fetch reading list", err);
+        setReadingList([]);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchList();
+  }, [userId, isOwner]);
+
+  if (isLoading || !readingList) return <Loader />;
+
+  const filtered = filterByStatus(readingList, statusFilter);
+
+  return (
+    <div className="container mx-auto px-6 py-12 max-w-6xl">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 mb-10">
+        <div>
+          <h1 className="heading-section text-foreground">
+            {isOwner
+              ? "My Reading List"
+              : `${profileName}'s Reading List`}
+          </h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            {isOwner
+              ? "Track your reading progress and manage your collection."
+              : "Viewing a public reading list."}
+          </p>
+        </div>
+        {isOwner && <Filter />}
+      </div>
+
+      <ReadingListView
+        readingList={filtered}
+        favoriteBookIds={favoriteBookIds}
+        onStatusChangeSuccess={isOwner ? refetchReadingList : undefined}
+      />
+    </div>
+  );
+}

--- a/app/reading-list/[userId]/page.tsx
+++ b/app/reading-list/[userId]/page.tsx
@@ -1,24 +1,16 @@
 import { notFound } from "next/navigation";
-import Filter from "@/app/_components/ReadingList/Filter";
-import ReadingListView from "@/app/_components/ReadingList/ReadingListView";
 import {
   getUserReadingList,
   getUserProfile,
   getPublicUserID,
 } from "@/app/_lib/service";
 import { auth } from "@/app/_lib/auth";
-import { ReadingListStatus } from "@/app/_lib/types";
-import Loader from "@/app/loading";
-import { Suspense } from "react";
-
-const VALID_STATUSES = new Set<string>(["to_read", "reading", "completed", "all"]);
+import ReadingListPageContent from "./_components/ReadingListPageContent";
 
 export default async function ReadingListPage(props: {
   params: Promise<{ userId: string }>;
-  searchParams: Promise<{ status: string }>;
 }) {
   const { userId } = await props.params;
-  const { status } = await props.searchParams;
 
   const session = await auth();
   let currentUserId: string | null = null;
@@ -28,43 +20,33 @@ export default async function ReadingListPage(props: {
 
   const isOwner = currentUserId === userId;
 
-  if (!isOwner) {
-    const profile = await getUserProfile(userId);
-    if (!profile?.isProfilePublic) notFound();
-  }
+  const profile = await getUserProfile(userId);
 
-  const [readingList, profile] = await Promise.all([
-    getUserReadingList(
-      userId,
-      VALID_STATUSES.has(status) ? (status as ReadingListStatus | "all") : undefined
-    ),
-    getUserProfile(userId),
-  ]);
+  if (!isOwner && !profile?.isProfilePublic) notFound();
 
   const favoriteBookIds = profile?.favoriteBooks.map((b) => b.id) ?? [];
+  const profileName = profile?.name ?? "User";
+
+  if (isOwner) {
+    return (
+      <ReadingListPageContent
+        userId={userId}
+        isOwner
+        profileName={profileName}
+        favoriteBookIds={favoriteBookIds}
+      />
+    );
+  }
+
+  const readingList = await getUserReadingList(userId);
 
   return (
-    <div className="container mx-auto px-6 py-12 max-w-6xl">
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 mb-10">
-        <div>
-          <h1 className="heading-section text-foreground">
-            {isOwner ? "My Reading List" : `${profile?.name ?? "User"}'s Reading List`}
-          </h1>
-          <p className="text-muted-foreground mt-1 text-sm">
-            {isOwner
-              ? "Track your reading progress and manage your collection."
-              : "Viewing a public reading list."}
-          </p>
-        </div>
-        {isOwner && <Filter />}
-      </div>
-
-      <Suspense fallback={<Loader />}>
-        <ReadingListView
-          readingList={readingList}
-          favoriteBookIds={favoriteBookIds}
-        />
-      </Suspense>
-    </div>
+    <ReadingListPageContent
+      userId={userId}
+      isOwner={false}
+      profileName={profileName}
+      favoriteBookIds={favoriteBookIds}
+      initialData={readingList}
+    />
   );
 }


### PR DESCRIPTION
# PR: Cache Layer, Reading List Sync Fixes & Mobile Nav Improvements

## Summary
This PR introduces a localStorage cache-aside layer for book details and the signed-in user’s reading list, with explicit invalidation on mutations and a manual “Clear cache” control on the profile page. It also fixes stale UI after status updates by refetching the reading list and invalidating per-book cache, and improves mobile navigation so the menu closes after selecting a link.

---

## What Changed

### Cache Layer (app/_lib/cache.ts)
- Namespaced keys:
  - librislist:book:<googleBookId>
  - librislist:reading-list:<userId>
- TTLs:
  - Books: 30 minutes
  - Reading list: 10 minutes
- Helpers:
  - getCache
  - setCache
  - invalidateCache
  - invalidateCacheByPrefix
  - clearAppCache

---

### Book Details (app/books/[bookId]/page.tsx)
- Implemented cache-aside for `/api/books/:id`
- Invalidation:
  - Add/remove/status change → invalidate reading list prefix
  - Status change → also invalidate current book cache key
- Remove flow:
  - Uses client navigation
  - removeBookFromListAction no longer redirects

---

### Server Actions (app/_lib/actions.ts)
- removeBookFromListAction now returns:
  `{ success, userId }`
- Uses `revalidatePath` instead of redirect

---

### Reading List (app/reading-list/[userId]/)

#### Owner View
- ReadingListPageContent:
  - Loads reading list via cache-aside + API
- Client-side filtering on full list
- Calls `refetchReadingList` after status changes for immediate UI updates

#### Non-Owner (Public View)
- Uses server-fetched `initialData`
- No client-side cache used

---

### API (app/api/reading-list/[userId]/route.ts)
- Reads userId from route segment
- Restricts access to signed-in user

---

### Status Updates
- StatusSelect:
  - Invalidates reading list cache and current book cache
  - Optional `onStatusUpdated` callback triggers refetch
- Prop flow:
  `ReadingListPageContent → ReadingListView → ReadingListTableBody → StatusSelect`

---

### Profile
- Added owner-only Settings card
- Includes `ClearCacheButton`:
  - Clears all `librislist:*` cache keys

---

### Mobile Navigation (app/_components/Nav/MobileNav.tsx)
- Replaced checkbox toggle with React state
- Menu now closes when selecting:
  - Navigation links
  - Profile
  - Sign in / Sign out

---

## Testing Suggestions

### Cache Behavior
- Visit a book detail page twice:
  - Second visit uses cache
- Hard refresh or clear cache:
  - Fetches fresh data

---

### Reading List
- Change book status:
  - Badge updates immediately
  - Filters update without reload
- Navigate between book page and My Reads:
  - Status remains consistent

---

### Profile
- Click Clear cache:
  - Removes all `librislist:*` entries
  - Next load refetches data

---

### Mobile UX
- Open mobile menu:
  - Tap any link → menu closes correctly